### PR TITLE
Add dbt models for process_video normalization and mart

### DIFF
--- a/standup_project/dbt_project.yml
+++ b/standup_project/dbt_project.yml
@@ -1,4 +1,3 @@
-
 # Name your project! Project names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
@@ -25,12 +24,14 @@ clean-targets:         # directories to be removed by `dbt clean`
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
-
-# In this example config, we tell dbt to build all models in the example/
-# directory as views. These settings can be overridden in the individual model
-# files using the `{{ config(...) }}` macro.
 models:
   standup_project:
-    # Config indicated by + and applies to all files under models/example/
-    example:
+    staging:
+      +schema: standup_staging
+      +materialized: view
+    core:
+      +schema: standup_core
+      +materialized: table
+    mart:
+      +schema: standup_mart
       +materialized: view

--- a/standup_project/models/core/core_llm_chapters.sql
+++ b/standup_project/models/core/core_llm_chapters.sql
@@ -1,0 +1,24 @@
+{{ config(materialized='table') }}
+
+with chapters as (
+    select
+        sp.video_id,
+        concat_ws('_', sp.video_id, chapter.value ->> 'id') as chapter_id,
+        (chapter.value ->> 'id')::int as start_segment_id,
+        (chapter.value ->> 'end_id')::int as end_segment_id,
+        chapter.value ->> 'theme' as theme,
+        chapter.value ->> 'summary' as summary
+    from {{ ref('stg_process_video') }} sp
+    cross join lateral jsonb_array_elements(coalesce(sp.llm_chapter_json -> 'chapters', '[]'::jsonb)) as chapter(value)
+    where nullif(chapter.value ->> 'id', '') is not null
+)
+
+select
+    video_id,
+    chapter_id,
+    start_segment_id,
+    end_segment_id,
+    theme,
+    summary
+from chapters
+where chapter_id is not null

--- a/standup_project/models/core/core_llm_classifications.sql
+++ b/standup_project/models/core/core_llm_classifications.sql
@@ -1,0 +1,34 @@
+{{ config(materialized='table') }}
+
+with base as (
+    select
+        sp.video_id,
+        concat_ws('_', sp.video_id, classification.value ->> 'id') as chapter_id,
+        nullif(btrim(classification.value ->> 'main_category'), '') as main_category,
+        nullif(btrim(classification.value ->> 'subcategory'), '') as subcategory,
+        classification.value ->> 'reason' as reason
+    from {{ ref('stg_process_video') }} sp
+    cross join lateral jsonb_array_elements(coalesce(sp.llm_classifier_json -> 'classifications', '[]'::jsonb)) as classification(value)
+    where nullif(classification.value ->> 'id', '') is not null
+)
+,
+categories as (
+    select
+        main_category,
+        row_number() over (order by main_category) as category_id
+    from (
+        select distinct main_category
+        from base
+        where nullif(main_category, '') is not null
+    ) distinct_categories
+)
+
+select
+    base.video_id,
+    base.chapter_id,
+    categories.category_id,
+    base.main_category,
+    base.subcategory,
+    base.reason
+from base
+join categories using (main_category)

--- a/standup_project/models/core/core_sound_features.sql
+++ b/standup_project/models/core/core_sound_features.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='table') }}
+
+with laughs as (
+    select
+        sp.video_id,
+        laugh.value
+    from {{ ref('stg_process_video') }} sp
+    cross join lateral jsonb_array_elements(coalesce(sp.sound_classifier_json -> 'laughs', '[]'::jsonb)) as laugh(value)
+)
+
+select
+    video_id,
+    nullif(value ->> 'time_offset', '')::numeric as time_offset,
+    nullif(value ->> 'score', '')::numeric as score
+from laughs
+where nullif(value ->> 'time_offset', '') is not null

--- a/standup_project/models/core/core_transcript_segments.sql
+++ b/standup_project/models/core/core_transcript_segments.sql
@@ -1,0 +1,22 @@
+{{ config(materialized='table') }}
+
+with segments as (
+    select
+        sp.video_id,
+        (segment.key)::int as segment_id,
+        nullif(segment.value ->> 'start', '')::numeric as start_s,
+        nullif(segment.value ->> 'end', '')::numeric as end_s,
+        segment.value ->> 'text' as text
+    from {{ ref('stg_process_video') }} sp
+    cross join lateral jsonb_each(coalesce(sp.transcribe_json, '{}'::jsonb)) as segment(key, value)
+    where nullif(segment.key, '') is not null
+)
+
+select
+    video_id,
+    segment_id,
+    start_s,
+    end_s,
+    text
+from segments
+where segment_id is not null

--- a/standup_project/models/core/core_videos.sql
+++ b/standup_project/models/core/core_videos.sql
@@ -1,0 +1,17 @@
+{{ config(materialized='table') }}
+
+select
+    video_id,
+    playlist_id,
+    playlist_title,
+    channel_id,
+    channel_name,
+    video_title,
+    video_url,
+    duration,
+    like_count,
+    view_count,
+    comment_count,
+    upload_date,
+    process_status
+from {{ ref('stg_process_video') }}

--- a/standup_project/models/mart/mart_video_analysis.sql
+++ b/standup_project/models/mart/mart_video_analysis.sql
@@ -1,0 +1,63 @@
+{{ config(materialized='view') }}
+
+with videos as (
+    select * from {{ ref('core_videos') }}
+),
+chapters as (
+    select * from {{ ref('core_llm_chapters') }}
+),
+classifications as (
+    select * from {{ ref('core_llm_classifications') }}
+),
+transcript_segments as (
+    select * from {{ ref('core_transcript_segments') }}
+),
+chapter_segments as (
+    select
+        ch.chapter_id,
+        count(ts.segment_id) as segment_count
+    from chapters ch
+    left join transcript_segments ts
+        on ch.video_id = ts.video_id
+       and ts.segment_id between ch.start_segment_id and ch.end_segment_id
+    group by ch.chapter_id
+),
+laughs as (
+    select
+        video_id,
+        count(*) as laugh_events,
+        sum(score) as total_laugh_score
+    from {{ ref('core_sound_features') }}
+    group by video_id
+)
+
+select
+    v.video_id,
+    v.video_title,
+    v.video_url,
+    v.channel_id,
+    v.channel_name,
+    v.playlist_id,
+    v.playlist_title,
+    v.duration,
+    v.view_count,
+    v.like_count,
+    v.comment_count,
+    v.upload_date,
+    coalesce(l.laugh_events, 0) as laugh_events,
+    coalesce(l.total_laugh_score, 0.0) as total_laugh_score,
+    ch.chapter_id,
+    ch.start_segment_id,
+    ch.end_segment_id,
+    coalesce(cs.segment_count, 0) as segment_count,
+    ch.theme,
+    ch.summary,
+    cls.category_id,
+    cls.main_category,
+    cls.subcategory,
+    cls.reason
+from videos v
+left join laughs l on v.video_id = l.video_id
+left join chapters ch on v.video_id = ch.video_id
+left join chapter_segments cs on ch.chapter_id = cs.chapter_id
+left join classifications cls on ch.chapter_id = cls.chapter_id

--- a/standup_project/models/staging/_sources.yml
+++ b/standup_project/models/staging/_sources.yml
@@ -1,0 +1,7 @@
+version: 2
+
+sources:
+  - name: standup_raw
+    schema: standup_raw
+    tables:
+      - name: process_video

--- a/standup_project/models/staging/stg_process_video.sql
+++ b/standup_project/models/staging/stg_process_video.sql
@@ -1,0 +1,26 @@
+{{ config(materialized='view') }}
+
+with source_data as (
+    select
+        video_id,
+        playlist_id,
+        playlist_title,
+        channel_id,
+        channel_name,
+        video_title,
+        video_url,
+        (video_meta_json ->> 'duration')::int as duration,
+        (video_meta_json ->> 'like_count')::bigint as like_count,
+        (video_meta_json ->> 'view_count')::bigint as view_count,
+        (video_meta_json ->> 'comment_count')::int as comment_count,
+        to_date(nullif(video_meta_json ->> 'upload_date', ''), 'YYYYMMDD') as upload_date,
+        transcribe_json,
+        llm_chapter_json,
+        llm_classifier_json,
+        sound_classifier_json,
+        process_status
+    from {{ source('standup_raw', 'process_video') }}
+)
+
+select *
+from source_data

--- a/standup_project/tests/core_schema.yml
+++ b/standup_project/tests/core_schema.yml
@@ -1,0 +1,40 @@
+version: 2
+
+models:
+  - name: core_videos
+    columns:
+      - name: video_id
+        tests:
+          - not_null
+          - unique
+
+  - name: core_transcript_segments
+    columns:
+      - name: video_id
+        tests:
+          - not_null
+          - relationships:
+              to: ref('core_videos')
+              field: video_id
+
+  - name: core_llm_chapters
+    columns:
+      - name: chapter_id
+        tests:
+          - not_null
+      - name: video_id
+        tests:
+          - relationships:
+              to: ref('core_videos')
+              field: video_id
+
+  - name: core_llm_classifications
+    columns:
+      - name: chapter_id
+        tests:
+          - relationships:
+              to: ref('core_llm_chapters')
+              field: chapter_id
+      - name: category_id
+        tests:
+          - not_null

--- a/standup_project/tests/test_core_transcript_segments_unique.sql
+++ b/standup_project/tests/test_core_transcript_segments_unique.sql
@@ -1,0 +1,7 @@
+-- Ensure transcript segments are unique per video
+select
+    video_id,
+    segment_id
+from {{ ref('core_transcript_segments') }}
+group by 1, 2
+having count(*) > 1


### PR DESCRIPTION
## Summary
- add staging model for `standup_raw.process_video` and declare the raw source
- build core tables for videos, transcripts, chapters, classifications, and sound features
- assemble a mart view joining content, categories, and laughter metrics with data tests for key constraints

## Testing
- not run (no warehouse connection configured)

------
https://chatgpt.com/codex/tasks/task_e_68d1a6a83f1483328c06dd808cff6988